### PR TITLE
fix: keyError problem

### DIFF
--- a/app.py
+++ b/app.py
@@ -299,7 +299,7 @@ for i in server_set_var:
 print('----')
 
 # Init-DB_care
-if set_data['db_type'] == 'sqlite':
+if data_db_set['type'] == 'sqlite':
     def back_up(back_time, back_up_where):
         print('----')
 
@@ -926,7 +926,7 @@ def main_upload():
 @app.route('/setting')
 @app.route('/setting/<int:num>', methods = ['POST', 'GET'])
 def setting(num = 0):
-    return main_setting_2(load_db.db_get(), num, set_data['db_type'])
+    return main_setting_2(load_db.db_get(), num, data_db_set['type'])
 
 @app.route('/other')
 def main_other():


### PR DESCRIPTION
Windows 11, Python 3.9.9 환경에서 발생하는 다음과 같은 KeyError를 해결합니다.

```
Traceback (most recent call last):
  File "C:\Users\doda\workspace\wiki\openNAMU\app.py", line 302, in <module>
    if set_data['db_type'] == 'sqlite':
KeyError: 'db_type
```

파이썬 버전 탓인지... 동작하지 않아 수정했는데, 확인해보시고 문제 없다면 머지 부탁드립니다.
