### PR TITLE
문단 링크를 위한 id 정정

### DIFF
--- a/views/main_css/js/render_wiki.js
+++ b/views/main_css/js/render_wiki.js
@@ -55,7 +55,7 @@ function get_link_state(data) {
 function get_heading_name() {
     let heading_name = document.getElementsByClassName('render_heading_text');
     for(let i = 0; i < heading_name.length; i++) {
-        heading_name[i].id = heading_name[i].innerText.replace(/^([0-9]+\.)+ /, '').replace(/✎ ⊖$/, '');
+        heading_name[i].id = heading_name[i].innerText.replace(/^([0-9]+\.)+ /, '').replace(/ ✎ ⊖$/, '');
     }
 }
 


### PR DESCRIPTION
<!--
stable, beta branch로 요청을 보내지 마십시오. 개발은 dev branch에서 이루어집니다.
Don't request merge your commit to stable, beta branch, please request to dev branch.
-->
`[[#개요|개요 문단으로]]` 방식 링크를 위해 부여된 id 뒤에 불필요한 공백이 남아있어, `✎ ⊖`와 함께 걸러지도록 했습니다.

![temp](https://user-images.githubusercontent.com/81607108/152180502-bb00fdca-c867-441a-b825-66881b1d8aa9.png)

