### PR TITLE
언어 설정에 따른 언어 태그 구문 추가

### DIFF
--- a/lang/en-US.json
+++ b/lang/en-US.json
@@ -1,4 +1,5 @@
 {
+    "language_tag": "en-US",
     "_comment_1_" : "Common",
         "server" : "Server",
         "filter" : "Filter",

--- a/lang/ko-KR.json
+++ b/lang/ko-KR.json
@@ -1,4 +1,5 @@
 {
+    "language_tag": "ko-KR",
     "delete_admin_group": "관리자 그룹 삭제",
     "document_name": "문서명",
     "non_login_alert": "비로그인 알림",

--- a/views/ringo/index.html
+++ b/views/ringo/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="{{'language_tag'|load_lang}}">
     <head>
         <meta charset="utf-8">
         {% if imp[3][0] != 0 %}

--- a/views/tenshi/index.html
+++ b/views/tenshi/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="{{'language_tag'|load_lang}}">
     <head>
         <meta charset="utf-8">
         {% if imp[3][0] != 0 %}


### PR DESCRIPTION
<!--
stable, beta branch로 요청을 보내지 마십시오. 개발은 dev branch에서 이루어집니다.
Don't request merge your commit to stable, beta branch, please request to dev branch.
-->
스킨과 언어 파일에 [BCP 47](https://tools.ietf.org/search/bcp47)([목록](https://r12a.github.io/app-subtags/))을 기준으로 하는 언어 태그 구문을 추가했습니다. 브라우저나 검색 봇이 페이지 언어를 올바르게 식별하도록 만들어 줍니다.

한국어, 일본어처럼 한 국가에서만 사용되는 언어는 지역코드를 붙인 `ko-KR` 형태 대신 `ko`로 생략을 권하고 있으나, 아직 혼용하는 사례도 있고 파일명과 일치시킬 겸 `ko-KR`로 입력했습니다.