### PR TITLE
리다이렉트 수정

### DIFF
--- a/route/login_register_submit.py
+++ b/route/login_register_submit.py
@@ -44,7 +44,7 @@ def login_register_submit_2(conn):
         ])
         conn.commit()
         
-        return redirect('/app_submit')
+        return redirect('/w/Frontpage')
     else:
         return easy_minify(flask.render_template(skin_check(),
             imp = [load_lang('approval_question'), wiki_set(), wiki_custom(), wiki_css([0, 0])],


### PR DESCRIPTION

안녕하세요. 개발하시느라 수고가 많으십니다!

오픈나무 정말 잘 쓰고 있는 와중에 한 가지 문제점을 발견해서 PR보냅니다.

가입시 승인 필요와 회원 가입 질문을 사용하는 상태에서, 비회원이 가입을 하게 되면 회원 가입 질문 입력 후에 /app_submit으로 리다이렉트 됩니다.

그런데 /app_submit에는 현재 회원 가입 승인 대기 중인 이용자들의 정보가 보이기때문에 비회원을 이곳으로 리다이렉트 하는 것은 적절하지 않은 것 같아서 /w/Frontpage로 리다이렉트 되도록 수정 해보았습니다.

아니면, 회원 가입 승인을 기다려달라는 문구를 담은 페이지를 만든 다음 그 곳으로 리다이렉트 시키는 것도 좋을 것 같습니다.

PR을 보내본 적이 없어서 제대로 작성한 것인지는 잘 모르겠습니다만... 오류 제보의 의미라도 있었으면 좋겠습니다! 오픈나무 항상 감사합니다 :)