### PR TITLE
콘텐츠 영역을 벗어난 표에 가로 스크롤 추가

### DIFF
--- a/views/main_css/css/main.css
+++ b/views/main_css/css/main.css
@@ -1,5 +1,5 @@
 /* 기본 전체 옵션 */
-body, html, video, table, iframe, input, textarea, img, hr, blockquote, pre, iframe, .table_safe {
+body, html, video, table, iframe, input, textarea, img, hr, blockquote, pre, iframe, .table_safe, .table_wrapper {
     max-width: 100%;
 }
 
@@ -23,6 +23,10 @@ input[type="checkbox"], input[type="radio"] {
 }
 
 /* 테이블 */
+.table_wrapper {
+    overflow-x: auto;
+}
+
 table {
     border-collapse: collapse;
 }

--- a/views/main_css/js/render_onmark.js
+++ b/views/main_css/js/render_onmark.js
@@ -1068,7 +1068,7 @@ function do_onmark_table_render_main(data) {
 
             if(table_data === '') {
                 table_data += '' + 
-                    '<div style="' + table_data_option['div'] + '">' +
+                    '<div class="table_wrapper" style="' + table_data_option['div'] + '">' +
                         '<table style="' + table_data_option['table'] + '">' +
                             table_caption +
                 '';


### PR DESCRIPTION
<!--
stable, beta branch로 요청을 보내지 마십시오. 개발은 dev branch에서 이루어집니다.
Don't request merge your commit to stable, beta branch, please request to dev branch.
-->
옆으로 길어져 지정된 콘텐츠 영역 폭 밖으로 넘치는 표에 가로 스크롤을 추가했습니다.
`views/main_css`에서 지정해뒀기에 스킨과 무관하게 적용됩니다.

전/후
![temp](https://user-images.githubusercontent.com/81607108/157449177-18994171-6fab-4438-91a4-96d9d1586ce9.png)