### PR TITLE
XSS, 이메일 중복 인증 대응

### DIFF
--- a/route/list_admin_use.py
+++ b/route/list_admin_use.py
@@ -21,7 +21,7 @@ def list_admin_use_2(conn):
 
         get_list = curs.fetchall()
         for data in get_list:
-            list_data += '<li>' + ip_pas(data[0]) + ' / ' + data[1] + ' / ' + data[2] + '</li>'
+            list_data += '<li>' + ip_pas(data[0]) + ' / ' + html.escape(data[1]) + ' / ' + data[2] + '</li>'
 
         list_data += '</ul>'
         list_data += next_fix('/admin_log?num=', num, get_list)

--- a/route/login_register_email.py
+++ b/route/login_register_email.py
@@ -9,7 +9,7 @@ def login_register_email_2(conn):
     if flask.request.method == 'POST':
         flask.session['reg_key'] = load_random_key(32)
 
-        user_email = flask.request.form.get('email', '')
+        user_email = re.sub(r'\\', '', flask.request.form.get('email', ''))
         email_data = re.search(r'@([^@]+)$', user_email)
         if email_data:
             email_data = email_data.group(1)

--- a/route/search_deep.py
+++ b/route/search_deep.py
@@ -46,7 +46,7 @@ def search_deep_2(conn, name):
 
                     test = data[1]
 
-                div_plus += '<li><a href="/w/' + url_pas(data[0]) + '">' + data[0] + '</a> (' + data[1] + ')</li>'
+                div_plus += '<li><a href="/w/' + url_pas(data[0]) + '">' + html.escape(data[0]) + '</a> (' + data[1] + ')</li>'
     else:
         curs.execute(db_change("select title from data where title like ? order by title limit ?, 50"),
             ['%' + name + '%', sql_num]

--- a/route/user_setting_email.py
+++ b/route/user_setting_email.py
@@ -12,7 +12,7 @@ def user_setting_email_2(conn):
         re_set_list = ['c_key']
         flask.session['c_key'] = load_random_key(32)
 
-        user_email = flask.request.form.get('email', '')
+        user_email = re.sub(r'\\', '', flask.request.form.get('email', ''))
         email_data = re.search(r'@([^@]+)$', user_email)
         if email_data:
             curs.execute(db_change("select html from html_filter where html = ? and kind = 'email'"), [email_data.group(1)])


### PR DESCRIPTION
문서명이"</a><script>스크립트</script> 형식일 때 권한사용 목록과 검색에서 스크립트가 실행되는 문제 수정
이메일 인증시 이스케이프 문자(\)를 넣으면 사용된 이메일이어도 다시 인증되는 문제 수정