### PR TITLE
chore: 기본 라이센스 값에 빈 문자열 할당

### DIFF
--- a/route/tool/func.py
+++ b/route/tool/func.py
@@ -1343,9 +1343,9 @@ def wiki_set(conn):
     db_data = curs.fetchall()
     data_list += [db_data[0][0]] if db_data and db_data[0][0] != '' else ['Wiki']
 
-    curs.execute(db_change('select data from other where name = "license"'))
+    curs.execute(db_change('select data from other where name = ?'), ['license'])
     db_data = curs.fetchall()
-    data_list += [db_data[0][0]] if db_data and db_data[0][0] != '' else ['ARR']
+    data_list += [db_data[0][0]] if db_data and db_data[0][0] != '' else ['']
 
     data_list += ['', '']
 


### PR DESCRIPTION
푸터에 노출되는 라이센스의 기본값이 ARR 인데, 의미가 불분명해서 빈 값이 좋겠다고 생각했습니다.