### PR TITLE
위키 렌더링 엔진에 [[../하위주소]] 와 같은 상대 내부 링크 지원 추가 

### DIFF
--- a/route/tool/func_render_namumark.py
+++ b/route/tool/func_render_namumark.py
@@ -199,26 +199,48 @@ class class_do_render_namumark:
             else:
                 return data[1]
 
-    def get_tool_link_fix(self, link_main, do_type = 'link'):
+    def get_tool_link_fix(self, link_main, do_type='link'):
         if do_type == 'link':
-            if link_main == '../':
+            if link_main.startswith('../'):
+                # ../하위문서 처리
+                levels_up = link_main.count('../')  # ../ 개수 계산
+                remaining_path = link_main.lstrip('../')  # ../ 제거 후 나머지 경로 추출
+
+                # 현재 문서 이름에서 상위 경로로 이동
                 link_main = self.doc_name
-                link_main = re.sub(r'(\/[^/]+)$', '', link_main)
+                for _ in range(levels_up):
+                    link_main = re.sub(r'(\/[^/]+)$', '', link_main)
+
+                # 상위 경로에 나머지 하위 문서 경로 추가
+                if remaining_path:
+                    link_main = f"{link_main}/{remaining_path}"
             elif re.search(r'^\/', link_main):
-                link_main = re.sub(r'^\/', lambda x : (self.doc_name + '/'), link_main)
-            elif re.search(r'^:(분류|category):', link_main, flags = re.I):
-                link_main = re.sub(r'^:(분류|category):', 'category:', link_main, flags = re.I)
-            elif re.search(r'^:(파일|file):', link_main, flags = re.I):
-                link_main = re.sub(r'^:(파일|file):', 'file:', link_main, flags = re.I)
-            elif re.search(r'^사용자:', link_main, flags = re.I):
-                link_main = re.sub(r'^사용자:', 'user:', link_main, flags = re.I)
+                # 절대 하위 문서 이동 처리
+                link_main = re.sub(r'^\/', lambda x: (self.doc_name + '/'), link_main)
+            elif re.search(r'^:(분류|category):', link_main, flags=re.I):
+                # 분류 문서 처리
+                link_main = re.sub(r'^:(분류|category):', 'category:', link_main, flags=re.I)
+            elif re.search(r'^:(파일|file):', link_main, flags=re.I):
+                # 파일 문서 처리
+                link_main = re.sub(r'^:(파일|file):', 'file:', link_main, flags=re.I)
+            elif re.search(r'^사용자:', link_main, flags=re.I):
+                # 사용자 문서 처리
+                link_main = re.sub(r'^사용자:', 'user:', link_main, flags=re.I)
         else:
-            # do_type == 'redirect'
-            if link_main == '../':
+            # 리다이렉트 처리 (do_type == 'redirect')
+            if link_main.startswith('../'):
+                # ../하위문서 처리 (리다이렉트 시)
+                levels_up = link_main.count('../')
+                remaining_path = link_main.lstrip('../')
+
                 link_main = self.doc_name
-                link_main = re.sub(r'(\/[^/]+)$', '', link_main)
+                for _ in range(levels_up):
+                    link_main = re.sub(r'(\/[^/]+)$', '', link_main)
+
+                if remaining_path:
+                    link_main = f"{link_main}/{remaining_path}"
             elif re.search(r'^\/', link_main):
-                link_main = re.sub(r'^\/', lambda x : (self.doc_name + '/'), link_main)
+                link_main = re.sub(r'^\/', lambda x: (self.doc_name + '/'), link_main)
             elif re.search(r'^분류:', link_main):
                 link_main = re.sub(r'^분류:', 'category:', link_main)
             elif re.search(r'^사용자:', link_main):


### PR DESCRIPTION
요약

이 PR은 위키 렌더링 엔진에 [[../하위문서]] 문법을 추가하여 상대 내부 링크를 지원합니다. 이를 통해 사용자는 현재 문서에서 상위 디렉터리로 이동한 뒤 하위 문서로 바로 접근할 수 있으며, 내부 네비게이션이 더욱 편리해지고 사용자 경험이 개선됩니다.

1.get_tool_link_fix 메서드 개선:
[[../하위문서]] 링크를 처리할 수 있도록 아래와 같은 로직 추가:
- ../의 개수를 계산하여 몇 단계 상위 디렉터리로 이동할지 결정.
- 현재 문서 이름에서 상위 디렉터리로 이동하는 반복 로직 추가.
-상위 디렉터리 이동 후 남아 있는 하위 경로를 추가하여 최종 경로 생성.

2.기존 기능 호환성:
- 기존의 [[../]] 및 [[/하위문서]] 문법은 변경 없이 유지되어 기존 문서 구조에 영향을 주지 않음.

관련 이슈 
#2271 상대 주소 링크 문법 추가 예정