### PR TITLE
math 매크로 line-height 문제 해결

### DIFF
--- a/views/main_css/css/main.css
+++ b/views/main_css/css/main.css
@@ -326,6 +326,11 @@
     border-left: 5px solid black;
 }
 
+/* math */
+.katex {
+    line-height: 0;
+}
+
 /* 취소선 */
 .opennamu_main s,
 .opennamu_main strike,


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/bb694f63-8b94-4e82-a163-eafd4c1276f1)

katex.min.css의`.katex {
    line-height: 1.2;
}` 때문에 line-height가 맞지 않아 본문보다 위로 올라가는 문제를 해결했습니다